### PR TITLE
PR #33: Scope1 Index + Show — Workout Plans List & Details

### DIFF
--- a/app/controllers/workout_plans_controller.rb
+++ b/app/controllers/workout_plans_controller.rb
@@ -1,5 +1,7 @@
 class WorkoutPlansController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_workout_plan, only: %i[show edit update destroy]
+  before_action :authorize_user!, only: %i[show edit update destroy]
 
   def index
     @workout_plans = current_user.workout_plans
@@ -30,5 +32,9 @@ class WorkoutPlansController < ApplicationController
 
   def set_workout_plan
     @workout_plan = WorkoutPlan.find(params[:id])
+  end
+
+  def authorize_user!
+    redirect_to workout_plans_path, alert: "Not authorized" unless @workout_plan.user == current_user
   end
 end

--- a/app/views/workout_plans/index.html.erb
+++ b/app/views/workout_plans/index.html.erb
@@ -1,2 +1,58 @@
-<h1>WorkoutPlans#index</h1>
-<p>Find me in app/views/workout_plans/index.html.erb</p>
+<div class="container py-5">
+  <div class="row mb-4">
+    <div class="col-md-8">
+      <h1>My Workout Plans</h1>
+      <p class="text-muted">Select a workout plan to view details and exercises</p>
+    </div>
+    <div class="col-md-4 text-end">
+      <%= link_to "+ New Plan", new_workout_plan_path, class: "btn btn-primary" %>
+    </div>
+  </div>
+
+  <% if @workout_plans.any? %>
+    <div class="row">
+      <% @workout_plans.each do |plan| %>
+        <div class="col-md-6 col-lg-4 mb-4">
+          <div class="card h-100 shadow-sm hover-shadow">
+            <div class="card-body">
+              <h5 class="card-title"><%= plan.goal %></h5>
+              <p class="card-text text-muted">
+                <strong>Level:</strong> <span class="badge bg-info"><%= plan.level %></span>
+              </p>
+              <p class="card-text">
+                <strong>Duration:</strong> <%= plan.duration_minutes %> min
+              </p>
+              <% if plan.equipment.present? %>
+                <p class="card-text small">
+                  <strong>Equipment:</strong> <%= plan.equipment %>
+                </p>
+              <% end %>
+              <p class="card-text text-muted small">
+                Created <%= time_ago_in_words(plan.created_at) %> ago
+              </p>
+            </div>
+            <div class="card-footer bg-white border-top">
+              <%= link_to "View", workout_plan_path(plan), class: "btn btn-sm btn-outline-primary" %>
+              <%= link_to "Edit", edit_workout_plan_path(plan), class: "btn btn-sm btn-outline-secondary" %>
+              <%= link_to "Delete", workout_plan_path(plan), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert alert-info" role="alert">
+      <h4 class="alert-heading">No workout plans yet</h4>
+      <p>You haven't created any workout plans. <%= link_to "Create one now", new_workout_plan_path, class: "alert-link" %></p>
+    </div>
+  <% end %>
+</div>
+
+<style>
+  .hover-shadow {
+    transition: box-shadow 0.3s ease;
+  }
+  .hover-shadow:hover {
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+  }
+</style>

--- a/app/views/workout_plans/show.html.erb
+++ b/app/views/workout_plans/show.html.erb
@@ -1,2 +1,130 @@
-<h1>WorkoutPlans#show</h1>
-<p>Find me in app/views/workout_plans/show.html.erb</p>
+<div class="container py-5">
+  <div class="row mb-4">
+    <div class="col-md-8">
+      <h1><%= @workout_plan.goal %></h1>
+      <p class="text-muted">
+        <strong>Level:</strong> <span class="badge bg-info"><%= @workout_plan.level %></span>
+        <strong class="ms-3">Duration:</strong> <%= @workout_plan.duration_minutes %> min
+      </p>
+    </div>
+    <div class="col-md-4 text-end">
+      <%= link_to "Edit", edit_workout_plan_path(@workout_plan), class: "btn btn-secondary me-2" %>
+      <%= link_to "Back to Plans", workout_plans_path, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-8">
+      <!-- Plan Details -->
+      <div class="card mb-4">
+        <div class="card-header bg-light">
+          <h5 class="mb-0">Plan Details</h5>
+        </div>
+        <div class="card-body">
+          <p><strong>Goal:</strong> <%= @workout_plan.goal %></p>
+          <p><strong>Level:</strong> <%= @workout_plan.level %></p>
+          <p><strong>Duration:</strong> <%= @workout_plan.duration_minutes %> minutes</p>
+          <% if @workout_plan.equipment.present? %>
+            <p><strong>Equipment:</strong> <%= @workout_plan.equipment %></p>
+          <% end %>
+          <p><strong>Created:</strong> <%= @workout_plan.created_at.strftime('%B %d, %Y') %></p>
+        </div>
+      </div>
+
+      <!-- AI Plan Section -->
+      <% if @workout_plan.ai_plan.present? || @workout_plan.raw_plan_text.present? %>
+        <div class="card mb-4">
+          <div class="card-header bg-light">
+            <h5 class="mb-0">AI-Generated Plan</h5>
+          </div>
+          <div class="card-body">
+            <% if @workout_plan.ai_plan.present? %>
+              <div class="alert alert-success">
+                <h6>Formatted Plan</h6>
+                <p><%= simple_format(@workout_plan.ai_plan) %></p>
+              </div>
+            <% end %>
+            <% if @workout_plan.raw_plan_text.present? %>
+              <div class="accordion" id="rawPlanAccordion">
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#rawPlanCollapse">
+                      Raw AI Output
+                    </button>
+                  </h2>
+                  <div id="rawPlanCollapse" class="accordion-collapse collapse" data-bs-parent="#rawPlanAccordion">
+                    <div class="accordion-body">
+                      <pre><code><%= @workout_plan.raw_plan_text %></code></pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- Exercises Section -->
+      <div class="card mb-4">
+        <div class="card-header bg-light d-flex justify-content-between align-items-center">
+          <h5 class="mb-0">Exercises (<%= @workout_plan.workout_exercises.count %>)</h5>
+          <%= link_to "+ Add Exercise", new_workout_plan_workout_exercise_path(@workout_plan), class: "btn btn-sm btn-primary" %>
+        </div>
+        <% if @workout_plan.workout_exercises.any? %>
+          <div class="list-group list-group-flush">
+            <% @workout_plan.workout_exercises.order(:step_order).each do |exercise| %>
+              <div class="list-group-item">
+                <div class="row align-items-center">
+                  <div class="col-md-1 text-center">
+                    <span class="badge bg-primary rounded-pill"><%= exercise.step_order %></span>
+                  </div>
+                  <div class="col-md-7">
+                    <h6 class="mb-1"><%= exercise.name %></h6>
+                    <p class="mb-0 text-muted small"><%= exercise.description %></p>
+                  </div>
+                  <div class="col-md-4 text-end">
+                    <small class="text-muted">
+                      <% if exercise.reps_or_duration.present? %>
+                        <strong>Reps/Duration:</strong> <%= exercise.reps_or_duration %><br>
+                      <% end %>
+                      <% if exercise.rest_seconds.present? %>
+                        <strong>Rest:</strong> <%= exercise.rest_seconds %>s
+                      <% end %>
+                    </small>
+                    <br>
+                    <%= link_to "Edit", edit_workout_plan_workout_exercise_path(@workout_plan, exercise), class: "btn btn-sm btn-outline-secondary mt-2" %>
+                    <%= link_to "Delete", workout_plan_workout_exercise_path(@workout_plan, exercise), method: :delete, data: { confirm: "Delete this exercise?" }, class: "btn btn-sm btn-outline-danger mt-2" %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="card-body">
+            <p class="text-muted mb-0">No exercises yet. <%= link_to "Add one", new_workout_plan_workout_exercise_path(@workout_plan), class: "alert-link" %></p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- Sidebar: Chat -->
+    <div class="col-md-4">
+      <div class="card sticky-top" style="top: 20px;">
+        <div class="card-header bg-light">
+          <h5 class="mb-0">AI Coach Chat</h5>
+        </div>
+        <div class="card-body d-flex flex-column" style="height: 400px;">
+          <div class="flex-grow-1 overflow-auto mb-3" id="chatHistory" style="border: 1px solid #dee2e6; padding: 10px; border-radius: 4px;">
+            <p class="text-muted small text-center">Chat messages will appear here</p>
+          </div>
+          <%= form_with url: workout_plan_ai_messages_path(@workout_plan), method: :post, local: true do |f| %>
+            <div class="input-group">
+              <%= f.text_field :content, placeholder: "Ask the AI coach...", class: "form-control", required: true %>
+              <%= f.submit "Send", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,20 +2,126 @@ puts "Cleaning database..."
 WorkoutPlan.destroy_all
 User.destroy_all
 
-puts "Creating user..."
-user = User.create!(
-  email: "testuser@example.com",
-  password: "password123"
+puts "Creating demo user..."
+demo_user = User.create!(
+  email: "demo@example.com",
+  password: "password"
 )
 
 puts "Creating workout plans..."
-WorkoutPlan.create!(
+
+# Plan 1: Beginner Fat Loss
+plan1 = WorkoutPlan.create!(
   level: "beginner",
-  goal: "fat_loss",
-  equipment: "none",
-  duration_minutes: 10,
-  ai_plan: "Sample",
-  user: user
+  goal: "Fat Loss",
+  equipment: "Dumbbells",
+  duration_minutes: 30,
+  ai_plan: "Warm up for 5 minutes, then perform 3 sets of each exercise with 60 seconds rest between sets.",
+  user: demo_user
 )
 
+# Add exercises to Plan 1
+WorkoutExercise.create!(
+  workout_plan: plan1,
+  step_order: 1,
+  name: "Dumbbell Squats",
+  description: "Stand with feet shoulder-width apart, holding dumbbells at shoulders. Lower into a squat.",
+  reps_or_duration: "12 reps",
+  rest_seconds: 60
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan1,
+  step_order: 2,
+  name: "Dumbbell Push-ups",
+  description: "Place hands on dumbbells in plank position, lower chest to dumbbells.",
+  reps_or_duration: "10 reps",
+  rest_seconds: 60
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan1,
+  step_order: 3,
+  name: "Dumbbell Rows",
+  description: "Hinge at hips, pull dumbbells to chest, focusing on shoulder blade movement.",
+  reps_or_duration: "12 reps",
+  rest_seconds: 60
+)
+
+# Plan 2: Intermediate Strength
+plan2 = WorkoutPlan.create!(
+  level: "intermediate",
+  goal: "Strength Building",
+  equipment: "Barbell, Rack",
+  duration_minutes: 45,
+  ai_plan: "Focus on compound lifts with heavy weight. 4 sets of 5 reps per exercise. Rest 2-3 minutes between sets.",
+  user: demo_user
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan2,
+  step_order: 1,
+  name: "Barbell Squats",
+  description: "Full body compound lift targeting legs, back, and core.",
+  reps_or_duration: "5 reps",
+  rest_seconds: 180
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan2,
+  step_order: 2,
+  name: "Barbell Bench Press",
+  description: "Chest dominant compound pressing movement.",
+  reps_or_duration: "5 reps",
+  rest_seconds: 180
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan2,
+  step_order: 3,
+  name: "Barbell Deadlifts",
+  description: "Ultimate full body lift, focus on proper form.",
+  reps_or_duration: "3 reps",
+  rest_seconds: 240
+)
+
+# Plan 3: Advanced HIIT
+plan3 = WorkoutPlan.create!(
+  level: "advanced",
+  goal: "Conditioning & Cardio",
+  equipment: "None",
+  duration_minutes: 20,
+  ai_plan: "High intensity interval training. 40 seconds work, 20 seconds rest. Repeat circuit 4 times.",
+  user: demo_user
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan3,
+  step_order: 1,
+  name: "Burpees",
+  description: "Full body explosive movement combining squat, push-up, and jump.",
+  reps_or_duration: "40 seconds",
+  rest_seconds: 20
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan3,
+  step_order: 2,
+  name: "Jump Squats",
+  description: "Explosive leg movement, landing softly.",
+  reps_or_duration: "40 seconds",
+  rest_seconds: 20
+)
+
+WorkoutExercise.create!(
+  workout_plan: plan3,
+  step_order: 3,
+  name: "Mountain Climbers",
+  description: "Core and cardio exercise, fast-paced leg drive.",
+  reps_or_duration: "40 seconds",
+  rest_seconds: 20
+)
+
+puts "Created user: #{demo_user.email}"
+puts "Created #{demo_user.workout_plans.count} workout plans with #{WorkoutExercise.count} exercises"
 puts "Done!"


### PR DESCRIPTION
Implement Scope1 (Index + Show) views and authorization for workout plans.

## Changes
- **Index view**: Display all user's workout plans as responsive cards with level, goal, duration
- **Show view**: Display full plan details with exercises listed in order, AI plan section, and chat sidebar
- **Authorization**: Add authenticate_user! and authorize_user! to prevent unauthorized access
- **Enhanced seeds**: Create 3 realistic workout plans with 9 exercises for testing

## User Stories
- As a visitor, I can see a list of challenges to navigate to the one I want to explore
- As a visitor, I can click on a challenge to see its details

## Acceptance Criteria
- [x] Index lists only logged-in user's plans
- [x] Show displays plan metadata, exercises in order, AI plan section
- [x] Non-owner cannot access/view other users' plans
- [x] All links work (View, Edit, Delete, Add Exercise)
- [x] Responsive design (mobile-friendly)
- [x] Demo data available via db:seed

## Testing Steps
1. Run `bin/rails db:seed`
2. Start `bin/rails server`
3. Sign in with demo@example.com / password
4. Navigate to /workout_plans
5. Verify index shows 3 plans
6. Click 'View' on a plan
7. Verify show page displays exercises in order
8. Try accessing another user's plan (should be blocked)

Closes #20