### PR TITLE
linking and index page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(resource)
+    workout_plans_path
+  end
+
+  def after_sign_out_path_for(resource)
+    root_path
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
   def home
+    redirect_to workout_plans_path if user_signed_in?
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,13 @@
-<h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 text-center">
+      <h1>Welcome to FitBuddyLite</h1>
+      <p class="lead">Your AI-powered workout companion</p>
+      
+      <div class="mt-4">
+        <%= link_to "Sign Up", "/users/sign_up", class: "btn btn-primary btn-lg" %>
+        <%= link_to "Sign In", "/users/sign_in", class: "btn btn-outline-primary btn-lg" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/workout_plans/index.html.erb
+++ b/app/views/workout_plans/index.html.erb
@@ -6,6 +6,7 @@
     </div>
     <div class="col-md-4 text-end">
       <%= link_to "+ New Plan", new_workout_plan_path, class: "btn btn-primary" %>
+      <%= link_to "Sign Out", destroy_user_session_path, method: :delete, class: "btn btn-outline-secondary" %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "pages#home"
 
+  # Allow GET requests for sign out (in addition to DELEE which is already built in in devise_for:users) as we want to get back to the home page after signing out
+  devise_scope :user do
+   get "/users/sign_out", to: "devise/sessions#destroy"
+  end
+
+
   resources :workout_plans do
     resources :ai_messages, only: [:index, :create]
     resources :workout_exercises, except: [:index, :show]


### PR DESCRIPTION
## Pull Request Template

### Summary
<!--- Brief description of the change. Link to the issue if applicable. -->
Issue: [scope_6_linking_pages_and_review_home_page]()

### What & Why
- What: (one-liner)
- Why: (one-liner rationale)

### Changes
- Allow GET requests for sign out as we want to get back to the home page
- adapted application controller and created def after_sign_out path_for function leading to root path for sign out button
- Integrated a sign out button in the workout_plan view
- adapted home page layout view and linked buttons to users/sign_up and users/sign_in
- linked login button after being logged in to the workout_plan page

### How to test
1. Steps to reproduce / test locally
2. Commands to run (e.g., `bin/rails db:migrate`, `bin/rails test`)

### Checklist
- [ ] I added/updated tests
- [ ] I ran the test suite locally and it passed
- [ ] I updated `DEVELOPMENT.md` or docs if needed
- [ ] Migration included (if applicable) and backwards compatible or documented
- [ ] No secrets committed (checked `.env` vs `.env.example`)

### Labels (suggested)
Scope: `Scope:S0/S1/S2/S3`  
Priority: `priority:P0/P1/P2`

### Reviewer notes
(Any additional notes for reviewers)
