### PR TITLE
Fix AI error handling and chat migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Example environment variables for FitBuddyLite
 DATABASE_URL=postgres://localhost/fitbuddylite_development
-AI_API_KEY=your_api_key_here
 RAILS_ENV=development
+
+# OpenAI API key for AI chat functionality
+# Get your key from: https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-your-openai-api-key-here

--- a/app/controllers/ai_messages_controller.rb
+++ b/app/controllers/ai_messages_controller.rb
@@ -4,7 +4,7 @@ class AiMessagesController < ApplicationController
   before_action :set_chat
 
   def create
-    # 1) User message speichern
+    # 1) Save user message
     user_message = @chat.ai_messages.create!(
       user: current_user,
       workout_plan: @workout_plan,
@@ -12,13 +12,13 @@ class AiMessagesController < ApplicationController
       content: params.require(:ai_message).fetch(:content)
     )
 
-    # 2) Chat-Historie als Klartext erzeugen
+    # 2) Build chat history as plain text
     history_text = @chat.ai_messages.order(:created_at).map do |msg|
       speaker = msg.role == "user" ? "User" : "AI"
       "#{speaker}: #{msg.content}"
     end.join("\n")
 
-    # 3) Prompt erzeugen
+    # 3) Build prompt
     prompt = <<~TEXT
       You are a helpful fitness coach. Answer clearly and practically.
 
@@ -28,25 +28,31 @@ class AiMessagesController < ApplicationController
       AI:
     TEXT
 
-    # 4) AI-Antwort von RubyLLM
-    chat_llm = RubyLLM.chat
-    ai_response = chat_llm.ask(prompt)
-    ai_text =
-      if ai_response.respond_to?(:text)
-        ai_response.text.to_s   # RubyLLM::Message → echten Text holen
-      else
-        ai_response.to_s        # Fallback, falls irgendwann ein String zurückkommt
-      end
+    # 4) Get AI response from RubyLLM with error handling
+    begin
+      chat_llm = RubyLLM.chat
+      ai_response = chat_llm.ask(prompt)
+      ai_text =
+        if ai_response.respond_to?(:text)
+          ai_response.text.to_s   # RubyLLM::Message → extract actual text
+        else
+          ai_response.to_s        # Fallback if a string is returned
+        end
 
-    # 5) AI Message speichern
-    @chat.ai_messages.create!(
-      user: current_user,
-      workout_plan: @workout_plan,
-      role: "assistant",
-      content: ai_text
-    )
+      # 5) Save AI message
+      @chat.ai_messages.create!(
+        user: current_user,
+        workout_plan: @workout_plan,
+        role: "assistant",
+        content: ai_text
+      )
 
-    redirect_to workout_plan_chat_path(@workout_plan, @chat)
+      redirect_to workout_plan_chat_path(@workout_plan, @chat), notice: "AI response received."
+    rescue StandardError => e
+      Rails.logger.error "AI API Error: #{e.message}"
+      redirect_to workout_plan_chat_path(@workout_plan, @chat), 
+                  alert: "Sorry, the AI service is temporarily unavailable. Please try again later."
+    end
   end
 
   private

--- a/db/migrate/20251204081327_make_ai_messages_chat_id_nullable_and_backfill.rb
+++ b/db/migrate/20251204081327_make_ai_messages_chat_id_nullable_and_backfill.rb
@@ -1,0 +1,28 @@
+class MakeAiMessagesChatIdNullableAndBackfill < ActiveRecord::Migration[7.1]
+  def up
+    # First, make chat_id nullable
+    change_column_null :ai_messages, :chat_id, true
+
+    # Create default chats for workout plans that have ai_messages without a chat
+    WorkoutPlan.find_each do |workout_plan|
+      orphaned_messages = workout_plan.ai_messages.where(chat_id: nil)
+      
+      if orphaned_messages.any?
+        # Create a default chat for this workout plan
+        default_chat = Chat.create!(
+          workout_plan: workout_plan,
+          user: workout_plan.user,
+          title: "Legacy Chat - #{workout_plan.goal}"
+        )
+        
+        # Associate all orphaned messages with the new chat
+        orphaned_messages.update_all(chat_id: default_chat.id)
+      end
+    end
+  end
+
+  def down
+    # Remove nullable constraint (make it required again)
+    change_column_null :ai_messages, :chat_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_03_144236) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_04_081327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_03_144236) do
     t.bigint "workout_plan_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "chat_id", null: false
+    t.bigint "chat_id"
     t.index ["chat_id"], name: "index_ai_messages_on_chat_id"
     t.index ["user_id"], name: "index_ai_messages_on_user_id"
     t.index ["workout_plan_id"], name: "index_ai_messages_on_workout_plan_id"


### PR DESCRIPTION
Adds error handling to AI controller, documents OpenAI key in .env.example, and creates migration to handle existing ai_messages without chat_id.